### PR TITLE
Add a principle of "Origin Sovereignty"

### DIFF
--- a/origin-sovereignty.md
+++ b/origin-sovereignty.md
@@ -1,0 +1,26 @@
+
+# Origin Sovereignty
+
+Origin sovereignty is the principle according to which the operator of a given domain should be the
+sole and exclusive controller of information pertaining to that domain. This information covers two
+primary aspects: the content that is published on that origin, and knowledge of the audience for
+that domain. This correspondingly leads to two primary considerations for how the Web must work:
+
+* The Web must be defined so that content published by one origin stays with that origin and does
+  not get aggregated or republished elsewhere. The Web is built on the back of hyperlinking, and
+  it is architecturally dubious to uproot content from its origin in order to provide it in a
+  different context.
+* The Web is built on the expectation that information about the online behaviour of users as it
+  takes place on a given origin must remain under the exclusive control of that origin's operator,
+  which alone must determine the means and purposes of its processing. Where that origin's operator
+  works with third parties, those third parties must only ever be service providers to that operator
+  and must not be able to independently reuse data obtained from providing that service. No other
+  monitoring on online behaviour is compatible with the well-being of the Web.
+
+These considerations ensure that the website publishers can operate a business without unfair
+competition from other parties that can impose tracking, force their content into aggregated
+experiences, or rely on user agents to unfairly extract knowledge of audiences.
+
+Exceptions can be considered to sovereignty when legitimate systems of collective governance exist
+that can support the common good (eg. a data trust of appropriately anonymised online behaviour in
+support of greater end-user security).

--- a/origin-sovereignty.md
+++ b/origin-sovereignty.md
@@ -1,25 +1,31 @@
 
 # Origin Sovereignty
 
-Origin sovereignty is the principle according to which the operator of a given domain should be the
-sole and exclusive controller of information pertaining to that domain. This information covers two
-primary aspects: the content that is published on that origin, and knowledge of the audience for
-that domain. This correspondingly leads to two primary considerations for how the Web must work:
+__Origin sovereignty__ is the principle according to which the operator of a given Web property
+(traditionally listed as the "author" though these operator entities vary widely in nature) should
+be the sole and exclusive controller of information pertaining to that Web property (typically a Web
+site, often mapped to a domain or origin). Such information covers two primary aspects: the content
+that is published on that property, and knowledge of the audience for that domain where the audience
+is the set of users who intentionally interacted with that property. Origin sovereignty leads to two
+primary considerations for how the Web must work:
 
-* The Web must be defined so that content published by one origin stays with that origin and does
-  not get aggregated or republished elsewhere. The Web is built on the back of hyperlinking, and
-  it is architecturally dubious to uproot content from its origin in order to provide it in a
-  different context.
+* The Web must be defined on the assumption that in the vast majority of cases the content published
+  by one Web property should stay with that property and does not need to be aggregated or
+  republished elsewhere, nor does it need to be integrated into a portal. The Web is built on a
+  foundation of hyperlinking, and it is architecturally dubious to uproot content from its origin in
+  order to provide it in a different context.
 * The Web is built on the expectation that information about the online behaviour of users as it
-  takes place on a given origin must remain under the exclusive control of that origin's operator,
-  which alone must determine the means and purposes of its processing. Where that origin's operator
-  works with third parties, those third parties must only ever be service providers to that operator
-  and must not be able to independently reuse data obtained from providing that service. No other
-  monitoring on online behaviour is compatible with the well-being of the Web.
+  takes place on a given Web property, being the property that users intended to interact with, must
+  remain under the exclusive control of that property's operator, which alone must determine the
+  means and purposes of its processing. Where that property's operator works with third parties,
+  those third parties must only ever be service providers to that operator and must not be able to
+  independently reuse data obtained from providing their service. No other monitoring on online
+  behaviour is compatible with the well-being of the Web.
 
-These considerations ensure that the website publishers can operate a business without unfair
+These considerations ensure that website publishers can operate a business without unfair
 competition from other parties that can impose tracking, force their content into aggregated
-experiences, or rely on user agents to unfairly extract knowledge of audiences.
+experiences, or rely on their control of infrastructure such as operating systems, ad serving, online
+portals, or user agents to unfairly extract knowledge about others' audiences.
 
 Exceptions can be considered to sovereignty when legitimate systems of collective governance exist
 that can support the common good (eg. a data trust of appropriately anonymised online behaviour in


### PR DESCRIPTION
Dear AB friends,

this PR seeks to do two things: 1) to experiment with a longer format, and 2) to propose a new principle.

Regarding the longer format, as discussed previously, I feel that the vision's principles need to be defined in somewhat greater detail than they currently are if they are to do some work and not just remain a list of nice thoughts that people working to build Web technology soon forget about. Ideas that are expressed too briefly, no matter how good they may be, are often difficult to put into practice. I believe fleshing things out more is more helpful when it comes to support discussions that happen in the trenches. I am eager to hear what your take on this is.

As to the specific property itself, my thinking is as follows. The AB has (IMHO rightly) worked on properties that support of "truth" on the Web in order to support stemming issues with fake news and radicalisation. I agree with that objective, but I don't think that we can usefully just posit support for truth — we need a way to make it work. (I also harbour doubts that truth-seeking of the kind we wish to see ever happens by anyone's leave.)

Rather than trying to specify the outcome, this property seeks to _enable_ the production of truth-seeking content particularly in news media. High-quality journalism is very expensive to produce; this property operates on the assumption that it would be in a better position to survive on the Web if it had access to a fairer and more sustainable business environment.

To offer a simplified view, there are two valuable things that media can develop: content, which draws readers, and knowledge of its audience, which draws advertisers. The way in which this works — or rather doesn't — on today's Web is that these media companies attempt to develop these and then platforms just help themselves to the content (through aggregation you can't refuse) and audience knowledge (through pervasive tracking, including at the UA level). It's a situation very similar to trying to run a bodega and having Walmart restock by helping themselves from your shelves.

This principle works on the premise that we will see better outcomes in the ecology of online information if we ensure that the Web can offer economic conditions healthy enough for quality content to set itself apart from the rest. However, it seems sound on broader principles as well, notably those that underlie the [CPNI](https://en.wikipedia.org/wiki/Customer_proprietary_network_information) or that are covered in Lina Khan's [The Separation of Platforms and Commerce](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3180174).

I look forward to your feedback!